### PR TITLE
Enhancement/issue_22

### DIFF
--- a/tuneta/config.py
+++ b/tuneta/config.py
@@ -41,6 +41,7 @@ tune_params = [
     "lower_length",
     "lower_period",
     "ma_length",
+    "mamode",
     "max_lookback",
     "maxperiod",
     "medium",
@@ -279,7 +280,7 @@ pandas_ta_indicators = [
     "pta.hilo",
     "pta.hl2",
     "pta.hlc3",
-    # "pta.hma", # remove when pandas-ta development is merged
+    # "pta.hma", # does not accept low ranges
     "pta.hwma",
     "pta.ichimoku",
     "pta.jma",
@@ -366,6 +367,26 @@ pandas_ta_indicators = [
     # "pta.vwma", # remove when pandas-ta development is merged
     # "pta.wb_tsv", # remove when pandas-ta development is merged
 ]
+
+pandas_ta_mamodes = {
+    "dema": 0,
+    "ema": 1,
+    "fwma": 2,
+    "hma": 3,
+    "linreg": 4,
+    "midpoint": 5,
+    "pwma": 6,
+    "rma": 7,
+    "sinwma": 8,
+    "sma": 9,
+    "swma": 10,
+    "t3": 11,
+    "tema": 12,
+    "trima": 13,
+    "vidya": 14,
+    "wma": 15,
+    "zlma": 16,
+}
 
 finta_indicatrs = [
     "fta.SMA",

--- a/tuneta/tune_ta.py
+++ b/tuneta/tune_ta.py
@@ -44,6 +44,7 @@ class TuneTA:
         indicators=["tta"],
         ranges=[(3, 180)],
         early_stop=99999,
+        max_clusters=10,
         min_target_correlation=0.001,
         remove_consecutive_duplicates=False,
     ):
@@ -134,7 +135,26 @@ class TuneTA:
                         fn += f"X.{param}, "
                     elif param in tune_params:
                         suggest = True
-                        fn += f"{param}=trial.suggest_int('{param}', {low}, {high}), "
+                        if param == "mamode":
+                            if "pta" in fn and not any(
+                                [
+                                    indicator
+                                    for indicator in [
+                                        "inertia",
+                                        "qqe",
+                                        "kama",
+                                        "smma",
+                                        "zlma",
+                                        "rvi",
+                                    ]
+                                    if (indicator in fn)
+                                ]
+                            ):
+                                fn += f"{param}=trial.suggest_categorical('{param}', {pandas_ta_mamodes}), "
+                        else:
+                            fn += (
+                                f"{param}=trial.suggest_int('{param}', {low}, {high}), "
+                            )
                 if "pta" in fn:
                     fn += "lookahead=False, "
                 fn += ")"
@@ -151,6 +171,7 @@ class TuneTA:
                             X,
                             y,
                             idx=idx,
+                            max_clusters=max_clusters,
                             verbose=self.verbose,
                             early_stop=early_stop,
                         )
@@ -166,6 +187,7 @@ class TuneTA:
                             X,
                             y,
                             idx=idx,
+                            max_clusters=max_clusters,
                             verbose=self.verbose,
                             early_stop=early_stop,
                         )


### PR DESCRIPTION
@jmrichardson,

Sir, this PR adds tunable mamodes. If `mamode` wasn't a param in the indicator, I left the code unchanged except for some improved error handling, which I found necessary when bumping up the number of trials and amount of data. If `mamode` is a param, I use `KPrototypes`, which uses `KMeans` for numerical features and `KModes` for categorical features. While I could have just converted the `mamodes` to numerical features and used `KMeans`, `KMeans` wasn't designed to handle categorical features. `KModes` seemed like the standard way to cluster categorical values and `KPrototypes` the default for mixed features. Unfortunately, I found that `KPrototypes` tends to fail at higher `num_clusters` when `trials` is also high, which I think is why https://towardsdatascience.com/the-k-prototype-as-clustering-algorithm-for-mixed-data-type-categorical-and-numerical-fe7c50538ebb used a `try`/`except` block in their `elbow` method. However, this wasn't a feature in `KElbowVisualizer`; so, in order to minimize code changes I added a `max_clusters` variable, which I set to `10` by default as it worked well. `max_clusters` is multiplied by 2 for the first clustering since this uses `KMeans` and the default you'd set was 20. Finally, while all the indicators below work in the `development` branch of `pandas-ta`, it's only due to the additional error handling I added. When checking on the `master` branch of `pandas-ta`, there were still errors for those indicators, but they occurred when executing `eval` in `eval_res`; so, I would have had to return `res=None` and then set `correlation=np.nan` to avoid that error. This didn't seem appropriate as there are other reasons things could fail at that point that we'd want the program to fail; so, I stopped those indicators from tuning `mamode`.

`["inertia", "qqe", "kama", "smma", "zlma", "rvi"]`

Adding `db_url` wasn't possible due to `pandas` `series` not being `serializable` to `json`. While I could have changed the format of some of the `set_user_attr` to solve this, it seemed better to leave this feature out as it's not really necessary upon further review. I also decided not to add a get_indicators_params function for the moment. This may come in a later PR.